### PR TITLE
dialyzer fixes

### DIFF
--- a/lib/concourse/pipeline.ex
+++ b/lib/concourse/pipeline.ex
@@ -3,13 +3,16 @@ defmodule Concourse.Pipeline do
 
   defstruct [:jobs, :resources]
 
-  @type t :: %Concourse.Pipeline{
+  @type t :: %__MODULE__{
           jobs: list(Concourse.Pipeline.Job.t()),
           resources: list(Concourse.Pipeline.Resource.t())
         }
 
   @spec parse(String.t()) :: nil | Concourse.Pipeline.t()
   def parse(filename) do
+    # Like many erlang functions, YamlElixir takes a charlist instead of a binary
+    # Dialyzer calls it a string() instead of a binary()
+    filename = String.to_charlist(filename)
     payload = YamlElixir.read_from_file(filename)
 
     case payload do
@@ -32,6 +35,7 @@ defmodule Concourse.Pipeline do
   defp resources([resource | resources]) do
     [
       %Concourse.Pipeline.Resource{
+        # [] can return nil, see https://hexdocs.pm/elixir/Access.html#c:fetch/2, and the summary of the Map.Module
         name: resource["name"],
         type: resource["type"],
         source: resource["source"]

--- a/lib/concourse/pipeline/resource.ex
+++ b/lib/concourse/pipeline/resource.ex
@@ -2,8 +2,8 @@ defmodule Concourse.Pipeline.Resource do
   defstruct [:name, :type, :source]
 
   @type t :: %Concourse.Pipeline.Resource{
-          name: String.t(),
-          type: String.t(),
-          source: map()
+          name: String.t() | nil,
+          type: String.t() | nil,
+          source: map() | nil
         }
 end


### PR DESCRIPTION
You can ignore the %__MODULE__ change, I was just eliminating that as a possibility.

The two main issues where the resource fields being assigned a potential nil, and the filename being a `string()` instead of `binary()` (or `String.t()` in elixir)
